### PR TITLE
Introduce pipeline helper

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -150,6 +150,12 @@ impl<F: AudioFloat> AudioComponent for ButterLowpass<F> {
     }
 }
 
+
+impl<F: AudioFloat> Pipeline for ButterLowpass<F> {
+    fn is_dropped(x: usize) -> bool { x == 1 }
+}
+
+
 /// Constant-gain bandpass filter (resonator).
 /// Filter gain is (nearly) independent of bandwidth.
 /// Input 0: input signal
@@ -239,3 +245,7 @@ impl<F: AudioFloat> AudioComponent for OnePoleLowpass<F> {
     }
 }
 
+
+impl<F: AudioFloat> Pipeline for OnePoleLowpass<F> {
+    fn is_dropped(x: usize) -> bool { x == 1 }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,6 +8,7 @@ use super::filter::*;
 use super::envelope::*;
 use super::noise::*;
 use super::oscillator::*;
+use numeric_array::typenum::*;
 
 // Function combinator environment. We like to define all kinds of useful functions here.
 
@@ -161,3 +162,21 @@ pub fn feedback<X, S>(x: Ac<X>) -> Ac<FeedbackComponent<X, S>> where
     X::Outputs: Size,
     S: Size,
     { Ac(FeedbackComponent::new(x.0)) }
+
+/// Replicate the input signals of a filter on its outputs to allow similar filters to be chained
+///
+/// # Examples
+/// ```
+/// # use fundsp::prelude::*;
+/// let _ = pipeline(lowpass()) >> lowpass();
+/// ```
+/// ```
+/// # use fundsp::prelude::*;
+/// let _ = pipeline(lowpass() | lowpass()) >> (lowpass() | lowpass());
+/// ```
+pub fn pipeline<T: Pipeline>(x: Ac<T>) -> Ac<PipelineComponent<T>>
+    where <T as AudioComponent>::Outputs: Cmp<<T as AudioComponent>::Inputs>,
+    <T as AudioComponent>::Outputs: IsLessOrEqual<<T as AudioComponent>::Inputs, Output = True>,
+{
+    Ac(PipelineComponent::new(x.0))
+}


### PR DESCRIPTION
Worked proof-of-concept for a simpler interleave-capable solution to pipelining filters. May want to rename the trait, the method, give it an operator, etc. etc.

One drawback of this approach is that e.g. `lowpass() * 0.5` loses support. A relaxed approach would be to move `is_dropped` onto the base trait and employ it in more universally. I'm not sure how gracefully it generalizes, however. For example, `lowpass() + lowpass()` cannot be pipelined, even though it has sensible behavior for `is_dropped`.