### PR TITLE
Move Discord info higher in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # FunDSP
 
+---
+
+## Rust Audio Discord
+
+To discuss FunDSP and other topics, come hang out with us at the
+[Rust Audio Discord](https://discord.gg/3hfDXS6hhQ).
+
+---
+
 ## Audio Processing and Synthesis Library for Rust
 
 [FunDSP](https://github.com/SamiPerttu/fundsp)
@@ -917,13 +926,6 @@ fn split_quad() -> An<impl AudioNode<Sample = f64, Inputs = U1, Outputs = U4>> {
     pass() ^ pass() ^ pass() ^ pass()
 }
 ```
-
----
-
-## Rust Audio Discord
-
-To discuss FunDSP and other topics, come hang out with us at the
-[Rust Audio Discord](https://discord.gg/3hfDXS6hhQ).
 
 ---
 


### PR DESCRIPTION
I don't think this looks the best but the README is quite long and the Discord link is at the very bottom which makes it a bit hard to find it so this is to help new users who might have questions, find the place to ask them. 