### PR TITLE
Make writing `Wave` generic over `std::io::Write`

### DIFF
--- a/src/wave.rs
+++ b/src/wave.rs
@@ -15,47 +15,47 @@ use std::sync::Arc;
 
 /// Write a 32-bit value to a WAV file.
 #[inline]
-fn write32(file: &mut File, x: u32) -> std::io::Result<()> {
+fn write32<W: Write>(writer: &mut W, x: u32) -> std::io::Result<()> {
     // WAV files are little endian.
-    file.write_all(&[x as u8, (x >> 8) as u8, (x >> 16) as u8, (x >> 24) as u8])?;
+    writer.write_all(&[x as u8, (x >> 8) as u8, (x >> 16) as u8, (x >> 24) as u8])?;
     std::io::Result::Ok(())
 }
 
 /// Write a 16-bit value to a WAV file.
 #[inline]
-fn write16(file: &mut File, x: u16) -> std::io::Result<()> {
-    file.write_all(&[x as u8, (x >> 8) as u8])?;
+fn write16<W: Write>(writer: &mut W, x: u16) -> std::io::Result<()> {
+    writer.write_all(&[x as u8, (x >> 8) as u8])?;
     std::io::Result::Ok(())
 }
 
 // Write WAV header, including the header of the data block.
-fn write_wav_header(
-    file: &mut File,
+fn write_wav_header<W: Write>(
+    writer: &mut W,
     data_length: usize,
     format: u16,
     channels: usize,
     sample_rate: usize,
 ) -> std::io::Result<()> {
-    file.write_all(b"RIFF")?;
-    write32(file, data_length as u32 + 36)?;
-    file.write_all(b"WAVE")?;
-    file.write_all(b"fmt ")?;
+    writer.write_all(b"RIFF")?;
+    write32(writer, data_length as u32 + 36)?;
+    writer.write_all(b"WAVE")?;
+    writer.write_all(b"fmt ")?;
     // Length of fmt block.
-    write32(file, 16)?;
+    write32(writer, 16)?;
     // Audio data format 1 = WAVE_FORMAT_PCM, 3 = WAVE_FORMAT_IEEE_FLOAT.
-    write16(file, format)?;
-    write16(file, channels as u16)?;
-    write32(file, sample_rate as u32)?;
+    write16(writer, format)?;
+    write16(writer, channels as u16)?;
+    write32(writer, sample_rate as u32)?;
     // Data rate in bytes per second.
     let sample_bytes = if format == 1 { 2 } else { 4 };
-    write32(file, (sample_rate * channels) as u32 * sample_bytes)?;
+    write32(writer, (sample_rate * channels) as u32 * sample_bytes)?;
     // Sample frame length in bytes.
-    write16(file, channels as u16 * 2)?;
+    write16(writer, channels as u16 * 2)?;
     // Bits per sample.
-    write16(file, 16)?;
-    file.write_all(b"data")?;
+    write16(writer, 16)?;
+    writer.write_all(b"data")?;
     // Length of data block.
-    write32(file, data_length as u32)?;
+    write32(writer, data_length as u32)?;
     std::io::Result::Ok(())
 }
 
@@ -355,12 +355,11 @@ impl Wave48 {
         }
     }
 
-    /// Saves the wave as a 16-bit WAV file.
+    /// Writes the wave as a 16-bit WAV to a buffer.
     /// Individual samples are clipped to the range -1...1.
-    pub fn save_wav16(&self, path: &Path) -> std::io::Result<()> {
-        let mut file = File::create(path)?;
+    pub fn write_wav16<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
         write_wav_header(
-            &mut file,
+            writer,
             2 * self.channels() * self.length(),
             1,
             self.channels(),
@@ -369,19 +368,18 @@ impl Wave48 {
         for i in 0..self.length() {
             for channel in 0..self.channels() {
                 let sample = round(clamp11(self.at(channel, i)) * 32767.49);
-                write16(&mut file, sample.to_i64() as u16)?;
+                write16(writer, sample.to_i64() as u16)?;
             }
         }
         std::io::Result::Ok(())
     }
 
-    /// Saves the wave as a 32-bit float WAV file.
+    /// Writes the wave as a 32-bit float WAV to a buffer.
     /// Samples are not clipped to any range but some
     /// applications may expect the range to be -1...1.
-    pub fn save_wav32(&self, path: &Path) -> std::io::Result<()> {
-        let mut file = File::create(path)?;
+    pub fn write_wav32<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
         write_wav_header(
-            &mut file,
+            writer,
             4 * self.channels() * self.length(),
             3,
             self.channels(),
@@ -390,10 +388,25 @@ impl Wave48 {
         for i in 0..self.length() {
             for channel in 0..self.channels() {
                 let sample = self.at(channel, i);
-                file.write_all(&sample.to_f32().to_le_bytes())?;
+                writer.write_all(&sample.to_f32().to_le_bytes())?;
             }
         }
         std::io::Result::Ok(())
+    }
+
+    /// Saves the wave as a 16-bit WAV file.
+    /// Individual samples are clipped to the range -1...1.
+    pub fn save_wav16(&self, path: &Path) -> std::io::Result<()> {
+        let mut file = File::create(path)?;
+        self.write_wav16(&mut file)
+    }
+
+    /// Saves the wave as a 32-bit float WAV file.
+    /// Samples are not clipped to any range but some
+    /// applications may expect the range to be -1...1.
+    pub fn save_wav32(&self, path: &Path) -> std::io::Result<()> {
+        let mut file = File::create(path)?;
+        self.write_wav32(&mut file)
     }
 }
 


### PR DESCRIPTION
`Wave32` and `Wave64` only allows writing to files. This PR makes it so that this allows writing to anything that implements `std::io::Write`.