### PR TITLE
ADSR Envelope Functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ rsor = "0.1.3"
 duplicate = "0.4.1"
 dyn-clone = "1.0.9"
 crossbeam = "0.8"
-midi-msg = "0.4.0"
-midir = "0.8.0"
-read_input = "0.8.6"
 
 [dev-dependencies]
 cpal = "0.14.0"
 anyhow = "1.0.62"
 plotters = "0.3.3"
 criterion = "0.3.6"
+midi-msg = "0.4.0"
+midir = "0.8.0"
+read_input = "0.8.6"
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ tinyvec = { version = "1.6.0", features = ["alloc"] }
 rsor = "0.1.3"
 duplicate = "0.4.1"
 dyn-clone = "1.0.9"
+crossbeam = "0.8"
+midi-msg = "0.4.0"
+midir = "0.8.0"
+read_input = "0.8.6"
 
 [dev-dependencies]
 cpal = "0.14.0"

--- a/examples/live_adsr.rs
+++ b/examples/live_adsr.rs
@@ -3,6 +3,10 @@
 //! corresponding pitches with the volume moderated by an `adsr_live()` envelope.
 //!
 //! The `create_sound()` function at the end of this file is where `adsr_live()` is employed.
+//!
+//! The MIDI input code is adapted from the
+//! [`test_read_input`](https://github.com/Boddlnagg/midir/blob/master/examples/test_read_input.rs)
+//! example in the [`midir` crate](https://github.com/Boddlnagg/midir).
 
 use fundsp::hacker::{envelope, midi_hz, triangle};
 use fundsp::prelude::AudioUnit64;

--- a/examples/live_adsr.rs
+++ b/examples/live_adsr.rs
@@ -1,0 +1,145 @@
+//! This is a fully functional demonstration of `adsr_live()`. It will
+//! listen to messages from the first connected MIDI input device it finds, and play the
+//! corresponding pitches with the volume moderated by an `adsr_live()` envelope.
+//!
+//! The 
+
+use fundsp::hacker::{envelope, midi_hz, triangle};
+use fundsp::prelude::AudioUnit64;
+use fundsp::adsr::{adsr_live, SoundMsg};
+use anyhow::bail;
+use midir::{Ignore, MidiInput, MidiInputPort};
+use midi_msg::{ChannelVoiceMsg, MidiMsg};
+use crossbeam::queue::SegQueue;
+use crossbeam::atomic::AtomicCell;
+use read_input::prelude::*;
+use cpal::{Device, Sample, StreamConfig, SampleFormat};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use std::sync::Arc;
+use std::collections::VecDeque;
+
+fn main() -> anyhow::Result<()> {
+    let mut midi_in = MidiInput::new("midir reading input")?;
+    let in_port = get_midi_device(&mut midi_in)?;
+
+    let messages = Arc::new(SegQueue::new());
+    run_output(messages.clone());
+    run_input(messages, midi_in, in_port)
+}
+
+fn get_midi_device(midi_in: &mut MidiInput) -> anyhow::Result<MidiInputPort> {
+    midi_in.ignore(Ignore::None);
+    let in_ports = midi_in.ports();
+    if in_ports.len() == 0 {
+        bail!("No MIDI devices attached")
+    } else {
+        println!("Chose MIDI device {}", midi_in.port_name(&in_ports[0]).unwrap());
+        Ok(in_ports[0].clone())
+    }
+}
+
+fn run_input(outgoing_midi: Arc<SegQueue<MidiMsg>>, midi_in: MidiInput, in_port: MidiInputPort) -> anyhow::Result<()> {
+    println!("\nOpening connection");
+    let in_port_name = midi_in.port_name(&in_port)?;
+    let _conn_in = midi_in.connect(&in_port, "midir-read-input", move |_stamp, message, _| {
+        let (msg, _len) = MidiMsg::from_midi(&message).unwrap();
+        outgoing_midi.push(msg);
+    }, ()).unwrap();
+    println!("Connection open, reading input from '{in_port_name}'");
+
+    let _ = input::<String>().msg("(press enter to exit)...\n").get();
+    println!("Closing connection");
+    Ok(())
+}
+
+fn run_output(incoming_midi: Arc<SegQueue<MidiMsg>>) {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .expect("failed to find a default output device");
+    let config = device.default_output_config().unwrap();
+    match config.sample_format() {
+        SampleFormat::F32 => run_synth::<f32>(incoming_midi, device, config.into()),
+        SampleFormat::I16 => run_synth::<i16>(incoming_midi, device, config.into()),
+        SampleFormat::U16 => run_synth::<u16>(incoming_midi, device, config.into()),
+    }
+}
+
+fn run_synth<T: Sample>(incoming_midi: Arc<SegQueue<MidiMsg>>, device: Device, config: StreamConfig) {
+    let sample_rate = config.sample_rate.0 as f64;
+    let device = Arc::new(device);
+    let config = Arc::new(config);
+    std::thread::spawn(move || {
+        let mut sound_thread_messages: VecDeque<Arc<AtomicCell<SoundMsg>>> = VecDeque::new();
+        loop {
+            if let Some(m) = incoming_midi.pop() {
+                if let MidiMsg::ChannelVoice {channel:_, msg} = m {
+                    println!("Received {msg:?}");
+                    match msg {
+                        ChannelVoiceMsg::NoteOff {note:_, velocity:_} => {
+                            if let Some(m) = sound_thread_messages.back() {
+                                m.store(SoundMsg::Release);
+                            }
+                        }
+                        ChannelVoiceMsg::NoteOn {note, velocity} => {
+                            loop {
+                                match sound_thread_messages.pop_front() {
+                                    None => break,
+                                    Some(m) => m.store(SoundMsg::Finished)
+                                }
+                            }
+                            let note_m = Arc::new(AtomicCell::new(SoundMsg::Play));
+                            sound_thread_messages.push_back(note_m.clone());
+                            start_sound::<T>(note, velocity, note_m, sample_rate, device.clone(), config.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn start_sound<T: Sample>(note: u8, velocity: u8, note_m: Arc<AtomicCell<SoundMsg>>,
+                          sample_rate: f64, device: Arc<Device>, config: Arc<StreamConfig>) {
+    let mut sound = create_sound(note, velocity, note_m.clone());
+    sound.reset(Some(sample_rate));
+    let mut next_value = move || sound.get_stereo();
+    let channels = config.channels as usize;
+    std::thread::spawn(move || {
+        let err_fn = |err| eprintln!("an error occurred on stream: {err}");
+        let stream = device.build_output_stream(
+            &config,
+            move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+                write_data(data, channels, &mut next_value)
+            },
+            err_fn,
+        ).unwrap();
+
+        stream.play().unwrap();
+        loop {
+            match note_m.load() {
+                SoundMsg::Finished => break,
+                _ => {}
+            }
+        }
+    });
+}
+
+fn create_sound(note: u8, velocity: u8, note_m: Arc<AtomicCell<SoundMsg>>) -> Box<dyn AudioUnit64> {
+    let pitch = midi_hz(note as f64);
+    let volume = velocity as f64 / 127.0;
+    Box::new(envelope(move |_t| pitch) >> triangle() * adsr_live(0.2, 0.2, 0.4, 0.2, note_m) * volume * 2.0)
+}
+
+fn write_data<T: Sample>(output: &mut [T], channels: usize, next_sample: &mut dyn FnMut() -> (f64, f64)) {
+    for frame in output.chunks_mut(channels) {
+        let sample = next_sample();
+        let left: T = Sample::from::<f32>(&(sample.0 as f32));
+        let right: T = Sample::from::<f32>(&(sample.1 as f32));
+
+        for (channel, sample) in frame.iter_mut().enumerate() {
+            *sample = if channel & 1 == 0 {left} else {right};
+        }
+    }
+}

--- a/examples/live_adsr.rs
+++ b/examples/live_adsr.rs
@@ -2,7 +2,7 @@
 //! listen to messages from the first connected MIDI input device it finds, and play the
 //! corresponding pitches with the volume moderated by an `adsr_live()` envelope.
 //!
-//! The 
+//! The `create_sound()` function at the end of this file is where `adsr_live()` is employed.
 
 use fundsp::hacker::{envelope, midi_hz, triangle};
 use fundsp::prelude::AudioUnit64;

--- a/src/adsr.rs
+++ b/src/adsr.rs
@@ -1,0 +1,103 @@
+//! Attack-Decay-Sustain-Release Envelopes
+//!
+//! These envelopes are built upon the
+//! [`envelope()`](https://docs.rs/fundsp/0.9.0/fundsp/prelude/fn.envelope.html) function to
+//! control volume over time.
+//!
+//! When a sound begins, its volume increases from zero to one in a time interval called the
+//! "Attack". It then decreases from 1.0 to the "Sustain" volume in a time interval called the
+//! "Decay". It remains at the "Sustain" level for a while, after which it decreases from the
+//! "Sustain" level to 0.0 in a time interval called the "Release".
+//!
+//! Two envelopes are available: `adsr_live()` and `adsr_fixed()`.
+//! * The `adsr_live()` function does not have a predetermined "Sustain" time interval. Instead,
+//! it awaits a `SoundMsg::Release` message by way of its `note_m`
+//! [`AtomicCell`](https://docs.rs/crossbeam/latest/crossbeam/atomic/struct.AtomicCell.html)
+//! parameter indicating when to begin the release. It signals completion of the release by placing
+//! a `SoundMsg::Finished` message in the `note_m` parameter.
+//! * The 'adsr_fixed()` function works similarly, except that it does have a predetermined
+//! "Sustain" time interval. It will release early if it receives a `SoundMsg::Release` message.
+//! It also signals completion with a `SoundMsg::Finished` message.
+//!
+//! The example `live_adsr.rs` is a fully functional demonstration of `adsr_live()`. It will
+//! listen to messages from the first connected MIDI input device it finds, and play the
+//! corresponding pitches with the volume moderated by an `adsr_live()` envelope.
+
+
+use std::fmt::Debug;
+use std::sync::Arc;
+use crossbeam::atomic::AtomicCell;
+use super::Float;
+use super::prelude::{An, Envelope, lerp, lfo};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SoundMsg {
+    Play, Release, Finished
+}
+
+/// Returns a volume-modulating ADSR envelope. Release occurs when a `SoundMsg::Release` message
+/// is stored in `note_m`.
+pub fn adsr_live<F:Float>(attack: F, decay: F, sustain: F, release: F, note_m: Arc<AtomicCell<SoundMsg>>) -> An<Envelope<F, F, impl Fn(F)->F + Sized + Clone, F>> {
+    adsr(attack, decay, sustain, release, None, note_m)
+}
+
+/// Returns a volume-modulating ADSR envelope. Release occurs when a `SoundMsg::Release` message
+/// is stored in `note_m`, or when `sustain_time` has elapsed, whichever comes first.
+pub fn adsr_fixed<F:Float>(attack: F, decay: F, sustain_time: F, sustain_level: F, release: F, note_m: Arc<AtomicCell<SoundMsg>>) -> An<Envelope<F, F, impl Fn(F)->F + Sized + Clone, F>> {
+    adsr(attack, decay, sustain_level, release, Some(attack + decay + sustain_time), note_m)
+}
+
+fn adsr<F:Float>(attack: F, decay: F, sustain: F, release: F, release_start: Option<F>, note_m: Arc<AtomicCell<SoundMsg>>) -> An<Envelope<F, F, impl Fn(F)->F + Sized + Clone, F>> {
+    let adsr = Arc::new(AtomicCell::new(Adsr {attack, decay, sustain, release, release_start}));
+    lfo(move |t| {
+        if note_m.load() == SoundMsg::Release {
+            let mut adsr_inner = adsr.load();
+            adsr_inner.release(t);
+            adsr.store(adsr_inner);
+            note_m.store(SoundMsg::Play);
+        }
+        match adsr.load().volume(t) {
+            Some(v) => v,
+            None => {note_m.store(SoundMsg::Finished); F::from_f64(0.0)}
+        }
+    })
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Adsr<F:Float> {
+    attack: F, decay: F, sustain: F, release: F, release_start: Option<F>
+}
+
+impl <F:Float> Adsr<F> {
+    fn release(&mut self, time_now: F) {
+        self.release_start = Some(time_now);
+    }
+
+    fn volume(&self, time: F) -> Option<F> {
+        match self.release_start {
+            None => Some(self.ads(time)),
+            Some(release_start) => {
+                if time < release_start {
+                    Some(self.ads(time))
+                } else {
+                    let release_time = time - release_start;
+                    if release_time > self.release {
+                        None
+                    } else {
+                        Some(lerp(self.sustain, F::from_f64(0.0), release_time / self.release))
+                    }
+                }
+            }
+        }
+    }
+
+    fn ads(&self, time: F) -> F {
+        if time < self.attack {
+            lerp(F::from_f64(0.0), F::from_f64(1.0), time / self.attack)
+        } else if time - self.attack < self.decay {
+            lerp(F::from_f64(1.0), self.sustain, (time - self.attack) / self.decay)
+        } else {
+            self.sustain
+        }
+    }
+}

--- a/src/adsr.rs
+++ b/src/adsr.rs
@@ -28,7 +28,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use crossbeam::atomic::AtomicCell;
 use super::Float;
-use super::prelude::{An, Envelope, lerp, lfo};
+use super::prelude::{An, Envelope, lerp, envelope};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SoundMsg {
@@ -49,7 +49,7 @@ pub fn adsr_fixed<F:Float>(attack: F, decay: F, sustain_time: F, sustain_level: 
 
 fn adsr<F:Float>(attack: F, decay: F, sustain: F, release: F, release_start: Option<F>, note_m: Arc<AtomicCell<SoundMsg>>) -> An<Envelope<F, F, impl Fn(F)->F + Sized + Clone, F>> {
     let adsr = Arc::new(AtomicCell::new(Adsr {attack, decay, sustain, release, release_start}));
-    lfo(move |t| {
+    envelope(move |t| {
         if note_m.load() == SoundMsg::Release {
             let mut adsr_inner = adsr.load();
             adsr_inner.release(t);

--- a/src/hacker.rs
+++ b/src/hacker.rs
@@ -1,5 +1,6 @@
 //! The hacker prelude, a fully 64-bit environment for audio processing.
 
+pub use super::adsr::*;
 pub use super::audionode::*;
 pub use super::audiounit::*;
 pub use super::combinator::*;

--- a/src/hacker32.rs
+++ b/src/hacker32.rs
@@ -1,5 +1,6 @@
 //! The 32-bit hacker prelude, a 32-bit environment for audio processing.
 
+pub use super::adsr::*;
 pub use super::audionode::*;
 pub use super::audiounit::*;
 pub use super::combinator::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,7 @@ pub mod svf;
 pub mod system;
 pub mod wave;
 pub mod wavetable;
+pub mod adsr;
 
 // For Frame::generate.
 pub use generic_array::sequence::GenericSequence;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 //! Generic prelude.
 
+pub use super::adsr::*;
 pub use super::audionode::*;
 pub use super::audiounit::*;
 pub use super::combinator::*;


### PR DESCRIPTION
Seeking to implement an [ADSR Envelope](https://en.wikipedia.org/wiki/Envelope_(music)#ADSR) in `fundsp`, and inspired by #12, I wrote two ADSR functions. I placed them in the file `adsr.rs`. Attempting to follow the program's conventions, I re-exported them through `prelude`, `hacker`, and `hacker32`. I also created a full example, `live_adsr.rs`, which uses the `adsr_live()` function in response to live events from a MIDI instrument. I've tested it with two different instruments on two different computers and it works pretty well.