### PR TITLE
Improve API of `Var`

### DIFF
--- a/src/hacker.rs
+++ b/src/hacker.rs
@@ -1816,3 +1816,19 @@ pub fn phaser<X: Fn(f64) -> f64 + Clone>(
 ) -> An<impl AudioNode<Sample = f64, Inputs = U1, Outputs = U1>> {
     super::prelude::phaser::<f64, _>(feedback_amount, phase_f)
 }
+
+/// Variable constant. Outputs the (scalar) value of the variable.
+/// 
+/// This uses atomics internally and therefore
+/// should be safe to manipulate from other threads.
+/// - Output 0: value
+///
+/// ### Example: Add Chorus
+/// ```
+/// use fundsp::prelude::*;
+/// pass() & var(0, 0.2) * chorus(0, 0.015, 0.005, 0.5);
+/// ```
+#[inline]
+pub fn var(tag: Tag, value: f64) -> An<Var<f64>> {
+    An(Var::new(tag, value))
+}

--- a/src/hacker.rs
+++ b/src/hacker.rs
@@ -1818,7 +1818,7 @@ pub fn phaser<X: Fn(f64) -> f64 + Clone>(
 }
 
 /// Variable constant. Outputs the (scalar) value of the variable.
-/// 
+///
 /// This uses atomics internally and therefore
 /// should be safe to manipulate from other threads.
 /// - Output 0: value

--- a/src/hacker32.rs
+++ b/src/hacker32.rs
@@ -1816,3 +1816,19 @@ pub fn phaser<X: Fn(f32) -> f32 + Clone>(
 ) -> An<impl AudioNode<Sample = f32, Inputs = U1, Outputs = U1>> {
     super::prelude::phaser::<f32, _>(feedback_amount, phase_f)
 }
+
+/// Variable constant. Outputs the (scalar) value of the variable.
+///
+/// This uses atomics internally and therefore
+/// should be safe to manipulate from other threads.
+/// - Output 0: value
+///
+/// ### Example: Add Chorus
+/// ```
+/// use fundsp::prelude::*;
+/// pass() & var(0, 0.2) * chorus(0, 0.015, 0.005, 0.5);
+/// ```
+#[inline]
+pub fn var(tag: Tag, value: f32) -> An<Var<f32>> {
+    An(Var::new(tag, value))
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2384,7 +2384,7 @@ pub fn phaser<T: Real, X: Fn(T) -> T + Clone>(
 }
 
 /// Variable constant. Outputs the (scalar) value of the variable.
-/// 
+///
 /// This uses atomics internally and therefore
 /// should be safe to manipulate from other threads.
 /// - Output 0: value

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2382,3 +2382,19 @@ pub fn phaser<T: Real, X: Fn(T) -> T + Clone>(
                 >> (mul(feedback_amount) | sink()),
         )
 }
+
+/// Variable constant. Outputs the (scalar) value of the variable.
+/// 
+/// This uses atomics internally and therefore
+/// should be safe to manipulate from other threads.
+/// - Output 0: value
+///
+/// ### Example: Add Chorus
+/// ```
+/// use fundsp::prelude::*;
+/// pass() & var::<f32>(0, 0.2) * chorus(0, 0.015, 0.005, 0.5);
+/// ```
+#[inline]
+pub fn var<T: Variable>(tag: Tag, value: T) -> An<Var<T>> {
+    An(Var::new(tag, value))
+}


### PR DESCRIPTION
- Continuation of #16.
- Made the API similar to `Tagged`.
- Reexported in `prelude`, `hacker`, and `hacker32` as `var`.

EDIT:

By the way, if this is merged, then `Var` is just essentially a better `Tagged`. Should there two versions of the same thing, but one is potentially not thread safe and the other is?