### PR TITLE
Reworked ADSR function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-/target
-Cargo.lock
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target
+Cargo.lock
+.vscode
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ criterion = "0.4.0"
 midi-msg = "0.4.0"
 midir = "0.8.0"
 read_input = "0.8.6"
-crossbeam-queue = "0.3.6"
 
 [[bench]]
 name = "benchmark"

--- a/src/adsr.rs
+++ b/src/adsr.rs
@@ -1,57 +1,49 @@
-//! Attack-Decay-Sustain-Release Envelopes
+//! Attack-Decay-Sustain-Release Envelope
 //!
-//! These envelopes are built upon the
-//! [`envelope()`](https://docs.rs/fundsp/0.9.0/fundsp/prelude/fn.envelope.html) function to
+//! This envelope is built upon the
+//! [`envelope2()`](https://docs.rs/fundsp/0.9.0/fundsp/prelude/fn.envelope2.html) function to
 //! control volume over time.
 //!
 //! When a sound begins, its volume increases from zero to one in a time interval called the
 //! "Attack". It then decreases from 1.0 to the "Sustain" volume in a time interval called the
-//! "Decay". It remains at the "Sustain" level for a while, after which it decreases from the
+//! "Decay". It remains at the "Sustain" level until an external input indicates that the note
+//! is finished, after which it decreases from the
 //! "Sustain" level to 0.0 in a time interval called the "Release".
 //!
-//! Two envelopes are available: `adsr_live()` and `adsr_fixed()`.
-//! * The `adsr_live()` function does not have a predetermined "Sustain" time interval. Instead,
-//! it awaits a positive value in its `releasing` parameter to indicate when to begin the release.
-//! It signals completion of the release by storing a positive value in the `finished` parameter.
-//! * The 'adsr_fixed()` function works similarly, except that it does have a predetermined
-//! "Sustain" time interval. It also signals completion with a positive value in the `finished`
-//! parameter.
-//!
-//! The example `live_adsr.rs` is a fully functional demonstration of `adsr_live()`. It will
-//! listen to messages from the first connected MIDI input device it finds, and play the
-//! corresponding pitches with the volume moderated by an `adsr_live()` envelope.
+//! The example [`live_adsr.rs`](https://github.com/SamiPerttu/fundsp/blob/master/examples/live_adsr.rs)
+//! is a fully functional demonstration of `adsr_live()`. It will listen to messages from the first
+//! connected MIDI input device it finds, and play the corresponding pitches with the volume moderated by
+//! an `adsr_live()` envelope.
 
-use super::audionode::{Tag, Var, Variable};
-use super::prelude::{envelope, lerp, var, An, Envelope};
+use super::audionode::{Tag, Variable};
+use super::prelude::{envelope2, lerp, var, An, Envelope2};
 use super::Float;
 
 pub const ADSR_1: Tag = 100000;
 pub const ADSR_2: Tag = ADSR_1 + 1;
 
-pub fn adsr<F: Float + Variable>(
+pub fn adsr_live<F: Float + Variable>(
     attack: F,
     decay: F,
     sustain: F,
     release: F,
-    release_start: Option<F>,
-    releasing: An<Var<F>>,
-    finished: An<Var<F>>,
-) -> An<Envelope<F, F, impl Fn(F) -> F + Sized + Clone, F>> {
-    let release_start = var(ADSR_1, release_start.unwrap_or_else(|| F::from_f64(-1.0)));
-    envelope(move |time| {
-        if releasing.value() > F::from_f64(0.0) && release_start.value() < F::from_f64(0.0) {
+) -> An<Envelope2<F, F, impl Fn(F, F) -> F + Sized + Clone, F>> {
+    let neg1 = F::from_f64(-1.0);
+    let zero = F::from_f64(0.0);
+    let attack_start = var(ADSR_1, neg1);
+    let release_start = var(ADSR_2, neg1);
+    envelope2(move |time, control| {
+        if attack_start.value() < zero && control >= zero {
+            attack_start.set_value(time);
+            release_start.set_value(neg1);
+        } else if release_start.value() < zero && control < zero {
             release_start.set_value(time);
+            attack_start.set_value(neg1);
         }
-        if release_start.value() < F::from_f64(0.0) || time < release_start.value() {
-            ads(attack, decay, sustain, time)
+        if release_start.value() < zero {
+            ads(attack, decay, sustain, time - attack_start.value())
         } else {
-            let release_time = time - release_start.value();
-            if release_time > release {
-                finished.set_value(F::from_f64(1.0));
-                F::from_f64(0.0)
-            } else {
-                lerp(sustain, F::from_f64(0.0), release_time / release)
-            }
+            releasing(sustain, release, time - release_start.value())
         }
     })
 }
@@ -66,5 +58,13 @@ fn ads<F: Float>(attack: F, decay: F, sustain: F, time: F) -> F {
         } else {
             sustain
         }
+    }
+}
+
+fn releasing<F: Float>(sustain: F, release: F, release_time: F) -> F {
+    if release_time > release {
+        F::from_f64(0.0)
+    } else {
+        lerp(sustain, F::from_f64(0.0), release_time / release)
     }
 }

--- a/src/hacker.rs
+++ b/src/hacker.rs
@@ -30,7 +30,6 @@ pub use super::*;
 pub use super::read::*;
 
 //use num_complex::Complex64;
-use super::adsr::{adsr, ADSR_2};
 use std::sync::Arc;
 
 // Combinator environment.
@@ -702,53 +701,27 @@ where
     An(Envelope3::new(0.002, DEFAULT_SR, f))
 }
 
-/// This function accepts one input and outputs its value modulated by the ADSR volume controller.
+/// ADSR envelope.
 ///
-/// When a sound begins, its volume increases from zero to one in the time interval denoted by
-/// `attack`. It then decreases from 1.0 to the `sustain` volume in the time interval denoted by
-/// `decay`. It remains at the `sustain` level until a positive value is stored in
-/// `releaing`, after which it decreases from the `sustain` level to 0.0 in a time interval denoted
-/// by `release`. It will store a positive value in `finished` once the release time has completed.
+/// When a positive value is given by the input, its output increases from 0.0 to 1.0 in the time
+/// interval denoted by `attack`. It then decreases from 1.0 to the `sustain` level in the time
+/// interval denoted by `decay`. It remains at the `sustain` level until a negative value is given
+/// by the input, after which it decreases from the `sustain` level to 0.0 in a time interval
+/// denoted by `release`.
+///
+/// - Input 0: control start of attack and release
+/// - Output 0: scaled ADSR value from 0.0 to 1.0
 ///
 /// See [live_adsr.rs](https://github.com/SamiPerttu/fundsp/blob/master/examples/live_adsr.rs) for
-/// a program that uses this function to play music live from a MIDI instrument.
+/// a program that uses this function to control the volume of live notes from a MIDI instrument.
 #[inline]
 pub fn adsr_live(
     attack: f64,
     decay: f64,
     sustain: f64,
     release: f64,
-    releasing: An<Var<f64>>,
-    finished: An<Var<f64>>,
-) -> An<Envelope<f64, f64, impl Fn(f64) -> f64 + Sized + Clone, f64>> {
-    adsr(attack, decay, sustain, release, None, releasing, finished)
-}
-
-/// This function accepts one input and outputs its value modulated by the ADSR volume controller.
-///
-/// When a sound begins, its volume increases from zero to one in the time interval denoted by
-/// `attack`. It then decreases from 1.0 to the `sustain_level` volume in the time interval denoted
-/// by `decay`. It remains at `sustain_level` until the `sustain_time` expires, after which it
-/// decreases from `sustain_level` to 0.0 in a time interval denoted by `release`. It will store a
-/// positive value in `finished` once the release time has completed.
-#[inline]
-pub fn adsr_fixed(
-    attack: f64,
-    decay: f64,
-    sustain_time: f64,
-    sustain_level: f64,
-    release: f64,
-    finished: An<Var<f64>>,
-) -> An<Envelope<f64, f64, impl Fn(f64) -> f64 + Sized + Clone, f64>> {
-    adsr(
-        attack,
-        decay,
-        sustain_level,
-        release,
-        Some(attack + decay + sustain_time),
-        var(ADSR_2, 0.0),
-        finished,
-    )
+) -> An<Envelope2<f64, f64, impl Fn(f64, f64) -> f64 + Sized + Clone, f64>> {
+    super::adsr::adsr_live(attack, decay, sustain, release)
 }
 
 /// Maximum Length Sequence noise generator from an `n`-bit sequence (1 <= `n` <= 31).

--- a/src/hacker32.rs
+++ b/src/hacker32.rs
@@ -30,7 +30,6 @@ pub use super::*;
 pub use super::read::*;
 
 //use num_complex::Complex64;
-use super::adsr::{adsr, ADSR_2};
 use std::sync::Arc;
 
 // Combinator environment.
@@ -702,53 +701,27 @@ where
     An(Envelope3::new(0.002, DEFAULT_SR, f))
 }
 
-/// This function accepts one input and outputs its value modulated by the ADSR volume controller.
+/// ADSR envelope.
 ///
-/// When a sound begins, its volume increases from zero to one in the time interval denoted by
-/// `attack`. It then decreases from 1.0 to the `sustain` volume in the time interval denoted by
-/// `decay`. It remains at the `sustain` level until a positive value is stored in
-/// `releaing`, after which it decreases from the `sustain` level to 0.0 in a time interval denoted
-/// by `release`. It will store a positive value in `finished` once the release time has completed.
+/// When a positive value is given by the input, its output increases from 0.0 to 1.0 in the time
+/// interval denoted by `attack`. It then decreases from 1.0 to the `sustain` level in the time
+/// interval denoted by `decay`. It remains at the `sustain` level until a negative value is given
+/// by the input, after which it decreases from the `sustain` level to 0.0 in a time interval
+/// denoted by `release`.
+///
+/// - Input 0: control start of attack and release
+/// - Output 0: scaled ADSR value from 0.0 to 1.0
 ///
 /// See [live_adsr.rs](https://github.com/SamiPerttu/fundsp/blob/master/examples/live_adsr.rs) for
-/// a program that uses this function to play music live from a MIDI instrument.
+/// a program that uses this function to control the volume of live notes from a MIDI instrument.
 #[inline]
 pub fn adsr_live(
     attack: f32,
     decay: f32,
     sustain: f32,
     release: f32,
-    releasing: An<Var<f32>>,
-    finished: An<Var<f32>>,
-) -> An<Envelope<f32, f32, impl Fn(f32) -> f32 + Sized + Clone, f32>> {
-    adsr(attack, decay, sustain, release, None, releasing, finished)
-}
-
-/// This function accepts one input and outputs its value modulated by the ADSR volume controller.
-///
-/// When a sound begins, its volume increases from zero to one in the time interval denoted by
-/// `attack`. It then decreases from 1.0 to the `sustain_level` volume in the time interval denoted
-/// by `decay`. It remains at `sustain_level` until the `sustain_time` expires, after which it
-/// decreases from `sustain_level` to 0.0 in a time interval denoted by `release`. It will store a
-/// positive value in `finished` once the release time has completed.
-#[inline]
-pub fn adsr_fixed(
-    attack: f32,
-    decay: f32,
-    sustain_time: f32,
-    sustain_level: f32,
-    release: f32,
-    finished: An<Var<f32>>,
-) -> An<Envelope<f32, f32, impl Fn(f32) -> f32 + Sized + Clone, f32>> {
-    adsr(
-        attack,
-        decay,
-        sustain_level,
-        release,
-        Some(attack + decay + sustain_time),
-        var(ADSR_2, 0.0),
-        finished,
-    )
+) -> An<Envelope2<f32, f32, impl Fn(f32, f32) -> f32 + Sized + Clone, f32>> {
+    super::adsr::adsr_live(attack, decay, sustain, release)
 }
 
 /// Maximum Length Sequence noise generator from an `n`-bit sequence (1 <= `n` <= 31).


### PR DESCRIPTION
Having gained a lot more experience with `fundsp` over the last couple of months, I reworked the API for the ADSR envelope I contributed. 

Instead of having `var()` objects embedded in the ADSR envelope as parameters, I rewrote it to be controlled by a graph input instead. That graph input can be a `var()` that is externally controlled and even manipulated elsewhere in the graph. This seems like a better fit with the overall design of the crate. 

I rewrote the `live_adsr.rs` example as well. This new API design, in combination with my increased experience with `fundsp`, enabled me to simplify the example a lot. Here is how I use the `live_adsr()` function in the example:

```rust
fn create_sound(
    pitch: An<Var<f64>>,
    volume: An<Var<f64>>,
    pitch_bend: An<Var<f64>>,
    control: An<Var<f64>>,
) -> Box<dyn AudioUnit64> {
    Box::new(pitch_bend * pitch >> triangle() * (control >> adsr_live(0.1, 0.2, 0.4, 0.2)) * volume)
}
```

The `control` `var()` starts the attack when it is positive and starts the release when it is negative. The other three `var()` objects change the sound in different ways in response to MIDI events. 