### PR TITLE
Slight change to ADSR control value cutoff

### DIFF
--- a/src/adsr.rs
+++ b/src/adsr.rs
@@ -32,10 +32,10 @@ pub fn adsr_live<F: Float + Atomic>(
     let attack_start = var(&a);
     let release_start = var(&b);
     envelope2(move |time, control| {
-        if attack_start.value() < zero && control >= zero {
+        if attack_start.value() < zero && control > zero {
             attack_start.set_value(time);
             release_start.set_value(neg1);
-        } else if release_start.value() < zero && control < zero {
+        } else if release_start.value() < zero && control <= zero {
             release_start.set_value(time);
             attack_start.set_value(neg1);
         }

--- a/src/hacker.rs
+++ b/src/hacker.rs
@@ -681,9 +681,9 @@ where
 ///
 /// When a positive value is given by the input, its output increases from 0.0 to 1.0 in the time
 /// interval denoted by `attack`. It then decreases from 1.0 to the `sustain` level in the time
-/// interval denoted by `decay`. It remains at the `sustain` level until a negative value is given
-/// by the input, after which it decreases from the `sustain` level to 0.0 in a time interval
-/// denoted by `release`.
+/// interval denoted by `decay`. It remains at the `sustain` level until a zero or negative value
+/// is given by the input, after which it decreases from the `sustain` level to 0.0 in a time
+/// interval denoted by `release`.
 ///
 /// - Input 0: control start of attack and release
 /// - Output 0: scaled ADSR value from 0.0 to 1.0

--- a/src/hacker32.rs
+++ b/src/hacker32.rs
@@ -681,9 +681,9 @@ where
 ///
 /// When a positive value is given by the input, its output increases from 0.0 to 1.0 in the time
 /// interval denoted by `attack`. It then decreases from 1.0 to the `sustain` level in the time
-/// interval denoted by `decay`. It remains at the `sustain` level until a negative value is given
-/// by the input, after which it decreases from the `sustain` level to 0.0 in a time interval
-/// denoted by `release`.
+/// interval denoted by `decay`. It remains at the `sustain` level until a zero or negative value
+/// is given by the input, after which it decreases from the `sustain` level to 0.0 in a time
+/// interval denoted by `release`.
 ///
 /// - Input 0: control start of attack and release
 /// - Output 0: scaled ADSR value from 0.0 to 1.0

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -720,9 +720,9 @@ where
 ///
 /// When a positive value is given by the input, its output increases from 0.0 to 1.0 in the time
 /// interval denoted by `attack`. It then decreases from 1.0 to the `sustain` level in the time
-/// interval denoted by `decay`. It remains at the `sustain` level until a negative value is given
-/// by the input, after which it decreases from the `sustain` level to 0.0 in a time interval
-/// denoted by `release`.
+/// interval denoted by `decay`. It remains at the `sustain` level until a zero or negative value
+/// is given by the input, after which it decreases from the `sustain` level to 0.0 in a time
+/// interval denoted by `release`.
 ///
 /// - Input 0: control start of attack and release
 /// - Output 0: scaled ADSR value from 0.0 to 1.0


### PR DESCRIPTION
I previously wrote `adsr_live()` to start its release at a negative value only. I have found it helpful in ongoing work to also have a zero value signal a release. The change is minimal: a `>=` becomes a `>`, and a `<` becomes a `<=`. I updated the documentation comments accordingly.

Also, in light of the "Remove tagged constants" update, I edited some of the comments in `live_adsr.rs` to clarify where `shared()` is used and where `var()` is used.