### PR TITLE
Update wave.rs

### DIFF
--- a/src/wave.rs
+++ b/src/wave.rs
@@ -422,8 +422,9 @@ impl Wave48 {
         let fade_i = fade_n as usize;
         for i in 0..fade_i {
             let a = smooth5((fade_n - i as f64) / (fade_n + 1.0)) as f48;
+            let sample = self.len() - fade_i + i;
             for channel in 0..self.channels() {
-                self.set(channel, self.len() - fade_i + i, self.at(channel, i) * a);
+                self.set(channel, sample, self.at(channel, sample) * a);
             }
         }
     }


### PR DESCRIPTION
Previous implementation was sampling from the start of the waveform, which causes a discontinuity. This is particularly obvious when you use it in conjunction with `fade_in` or simply `fade`. 

Before fix:
![gen](https://user-images.githubusercontent.com/80861513/229593174-6bd523c3-5b35-4f92-87b1-a78cdda183af.png)

After fix:
![gen](https://user-images.githubusercontent.com/80861513/229593414-3d2041cd-8c49-40c7-943b-e5bc0a22e1d5.png)


(FYI I just quickly copied some of the plotting code so the legend is nonsense)