### PR TITLE
Add atan shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,7 @@ These are arguments to the `shape` opcode.
 - `Shape::Clip`: Clip signal to -1...1.
 - `Shape::ClipTo(minimum, maximum)`: Clip signal between the two arguments.
 - `Shape::Tanh(hardness)`: Apply `tanh` distortion with configurable hardness. Argument to `tanh` is multiplied by the hardness value.
+- `Shape::Atan(hardness)`: Apply `atan` distortion with configurable hardness. Argument to `atan` is multiplied by the hardness value.
 - `Shape::Softsign(hardness)`: Apply `softsign` distortion with configurable hardness. Argument to `softsign` is multiplied by the hardness value.
 - `Shape::Crush(levels)`: Apply a staircase function with configurable number of levels per unit.
 - `Shape::SoftCrush(levels)`: Apply a smooth staircase function with configurable number of levels per unit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,7 @@ pub trait Real: Num + Float {
     fn cos(self) -> Self;
     fn tan(self) -> Self;
     fn tanh(self) -> Self;
+    fn atan(self) -> Self;
 }
 
 macro_rules! impl_real {
@@ -242,6 +243,7 @@ macro_rules! impl_real {
         #[inline] fn cos(self) -> Self { self.cos() }
         #[inline] fn tan(self) -> Self { <$t>::tan(self) }
         #[inline] fn tanh(self) -> Self { <$t>::tanh(self) }
+        #[inline] fn atan(self) -> Self { <$t>::atan(self) }
     }) *
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -98,10 +98,15 @@ pub fn cos<T: Real>(x: T) -> T {
 pub fn tan<T: Real>(x: T) -> T {
     x.tan()
 }
-/// Hyperbolic tangent function. Squashes `x` to -1...1.
+/// Hyperbolic tangent function. Squashes `x` to (-1, 1).
 #[inline]
 pub fn tanh<T: Real>(x: T) -> T {
     x.tanh()
+}
+/// Inverse tangent function. Squashes `x` to (-π/2, π/2).
+#[inline]
+pub fn atan<T: Real>(x: T) -> T {
+    x.atan()
 }
 
 /// sqrt(2)

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -75,6 +75,9 @@ pub enum Shape<T: Real> {
     /// Apply `tanh` distortion with configurable hardness.
     /// Argument to `tanh` is multiplied by the hardness value.
     Tanh(T),
+    /// Apply `atan` distortion with configurable hardness.
+    /// Argument to `atan` is multiplied by the hardness value.
+    ATan(T),
     /// Apply `softsign` distortion with configurable hardness.
     /// Argument to `softsign` is multiplied by the hardness value.
     Softsign(T),
@@ -138,6 +141,7 @@ impl<T: Real> AudioNode for Shaper<T> {
             Shape::Clip => [clamp11(input)].into(),
             Shape::ClipTo(min, max) => [clamp(min, max, input)].into(),
             Shape::Tanh(hardness) => [tanh(input * hardness)].into(),
+            Shape::ATan(hardness) => [atan(input * hardness)].into(),
             Shape::Softsign(hardness) => [softsign(input * hardness)].into(),
             Shape::Crush(levels) => [round(input * levels) / levels].into(),
             Shape::SoftCrush(levels) => {
@@ -175,6 +179,11 @@ impl<T: Real> AudioNode for Shaper<T> {
             Shape::Tanh(hardness) => {
                 for (x, y) in output[0..size].iter_mut().zip(input[0..size].iter()) {
                     *x = tanh(*y * hardness);
+                }
+            }
+            Shape::ATan(hardness) => {
+                for (x, y) in output[0..size].iter_mut().zip(input[0..size].iter()) {
+                    *x = atan(*y * hardness);
                 }
             }
             Shape::Softsign(hardness) => {


### PR DESCRIPTION
Thanks for the awesome library! This PR defines a new `Shape` for arctan, which is supposed to clip a bit "[softer](https://cycling74.com/forums/atan-distortion-vs-tanh-distortion)" than the already supported tanh function.