### PR TITLE
Allow var() with Shared<T: Atomic>

### DIFF
--- a/src/hacker.rs
+++ b/src/hacker.rs
@@ -2152,7 +2152,7 @@ pub fn shared(value: f64) -> Shared<f64> {
 /// let wet = shared(0.2);
 /// pass() & var(&wet) * chorus(0, 0.015, 0.005, 0.5);
 /// ```
-pub fn var(shared: &Shared<f64>) -> An<Var<f64>> {
+pub fn var<T: Atomic>(shared: &Shared<T>) -> An<Var<T>> {
     An(Var::new(shared))
 }
 
@@ -2166,11 +2166,11 @@ pub fn var(shared: &Shared<f64>) -> An<Var<f64>> {
 /// let pitch = shared(69.0);
 /// var_fn(&pitch, |x| midi_hz(x)) >> follow(0.01) >> saw();
 /// ```
-pub fn var_fn<F, R>(shared: &Shared<f64>, f: F) -> An<VarFn<f64, F, R>>
+pub fn var_fn<T: Atomic, F, R>(shared: &Shared<T>, f: F) -> An<VarFn<T, F, R>>
 where
-    F: Clone + Fn(f64) -> R + Send + Sync,
-    R: ConstantFrame<Sample = f64>,
-    R::Size: Size<f64>,
+    F: Clone + Fn(T) -> R + Send + Sync,
+    R: ConstantFrame<Sample = T>,
+    R::Size: Size<T>,
 {
     An(VarFn::new(shared, f))
 }

--- a/src/hacker32.rs
+++ b/src/hacker32.rs
@@ -2153,7 +2153,7 @@ pub fn shared(value: f32) -> Shared<f32> {
 /// let wet = shared(0.2);
 /// pass() & var(&wet) * chorus(0, 0.015, 0.005, 0.5);
 /// ```
-pub fn var(shared: &Shared<f32>) -> An<Var<f32>> {
+pub fn var<T: Atomic>(shared: &Shared<T>) -> An<Var<T>> {
     An(Var::new(shared))
 }
 
@@ -2168,11 +2168,11 @@ pub fn var(shared: &Shared<f32>) -> An<Var<f32>> {
 /// let pitch = shared(69.0);
 /// var_fn(&pitch, |x| midi_hz(x)) >> follow(0.01) >> saw();
 /// ```
-pub fn var_fn<F, R>(shared: &Shared<f32>, f: F) -> An<VarFn<f32, F, R>>
+pub fn var_fn<T: Atomic, F, R>(shared: &Shared<T>, f: F) -> An<VarFn<T, F, R>>
 where
-    F: Clone + Fn(f32) -> R + Send + Sync,
-    R: ConstantFrame<Sample = f32>,
-    R::Size: Size<f32>,
+    F: Clone + Fn(T) -> R + Send + Sync,
+    R: ConstantFrame<Sample = T>,
+    R::Size: Size<T>,
 {
     An(VarFn::new(shared, f))
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -56,6 +56,44 @@ impl Atomic for f64 {
     }
 }
 
+impl Atomic for u32 {
+    type Storage = AtomicU32;
+
+    fn storage(t: Self) -> Self::Storage {
+        AtomicU32::from(t)
+    }
+
+    #[inline]
+    fn store(stored: &Self::Storage, t: Self) {
+        stored.store(t.to_bits(), std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[inline]
+    fn get_stored(stored: &Self::Storage) -> Self {
+        let u = stored.load(std::sync::atomic::Ordering::Relaxed);
+        u
+    }
+}
+
+impl Atomic for u64 {
+    type Storage = AtomicU64;
+
+    fn storage(t: Self) -> Self::Storage {
+        AtomicU64::from(t)
+    }
+
+    #[inline]
+    fn store(stored: &Self::Storage, t: Self) {
+        stored.store(t.to_bits(), std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[inline]
+    fn get_stored(stored: &Self::Storage) -> Self {
+        let u = stored.load(std::sync::atomic::Ordering::Relaxed);
+        u
+    }
+}
+
 impl Atomic for bool {
     type Storage = AtomicBool;
 


### PR DESCRIPTION
Extend the use of `var()` and `Shared<>` so it can be used with more atomic types.