### PR TITLE
add biquad_bank.rs as base for filter banks

### DIFF
--- a/src/biquad_bank.rs
+++ b/src/biquad_bank.rs
@@ -1,0 +1,236 @@
+use core::marker::PhantomData;
+use core::ops::Neg;
+use wide::{f32x8, f64x4};
+
+use super::audionode::*;
+use super::prelude::{U4, U8};
+use super::*;
+use numeric_array::ArrayLength;
+
+pub trait Realx<Size: ArrayLength>: Num + Sized + Neg<Output = Self> {
+    const PI: Self;
+    const TAU: Self;
+    fn exp(self) -> Self;
+    fn cos(self) -> Self;
+    fn sqrt(self) -> Self;
+    fn reduce_add(self) -> f32;
+    fn to_frame(self) -> Frame<f32, Size>;
+}
+
+impl Realx<U8> for f32x8 {
+    const PI: Self = f32x8::PI;
+    const TAU: Self = f32x8::TAU;
+
+    #[inline(always)]
+    fn exp(self) -> Self {
+        f32x8::exp(self)
+    }
+    #[inline(always)]
+    fn cos(self) -> Self {
+        f32x8::cos(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        f32x8::sqrt(self)
+    }
+    #[inline(always)]
+    fn reduce_add(self) -> f32 {
+        f32x8::reduce_add(self)
+    }
+    #[inline(always)]
+    fn to_frame(self) -> Frame<f32, U8> {
+        f32x8::to_array(self).into()
+    }
+}
+
+impl Realx<U4> for f64x4 {
+    const PI: Self = f64x4::PI;
+    const TAU: Self = f64x4::TAU;
+
+    #[inline(always)]
+    fn exp(self) -> Self {
+        f64x4::exp(self)
+    }
+    #[inline(always)]
+    fn cos(self) -> Self {
+        f64x4::cos(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        f64x4::sqrt(self)
+    }
+    #[inline(always)]
+    fn reduce_add(self) -> f32 {
+        f64x4::reduce_add(self) as f32
+    }
+    #[inline(always)]
+    fn to_frame(self) -> Frame<f32, U4> {
+        let array_f64: [f64; 4] = f64x4::to_array(self);
+        let array_f32: [f32; 4] = array_f64.map(|x| x as f32);
+        array_f32.into()
+    }
+}
+
+/// BiquadBank coefficients in normalized form using SIMD.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct BiquadCoefsBank<F, Size>
+where
+    F: Realx<Size>,
+    Size: ArrayLength,
+{
+    pub a1: F,
+    pub a2: F,
+    pub b0: F,
+    pub b1: F,
+    pub b2: F,
+    _marker: PhantomData<Size>,
+}
+
+impl<F, Size> BiquadCoefsBank<F, Size>
+where
+    F: Realx<Size>,
+    Size: ArrayLength,
+{
+    /// Return settings for a constant-gain bandpass resonator-bank.
+    /// Sample rate and center frequency are in Hz.
+    /// The overall gain of the filter is independent of bandwidth.
+    #[inline]
+    pub fn resonator(sample_rate: f32, center: F, q: F) -> Self {
+        let c = F::from_f64;
+        let sr = F::from_f32(sample_rate);
+        let r: F = (-F::PI * center / (q * sr)).exp();
+        let a1: F = c(-2.0) * r * (F::TAU * center / sr).cos();
+        let a2: F = r * r;
+        let b0: F = (c(1.0) - r * r).sqrt() * c(0.5);
+        let b1: F = c(0.0);
+        let b2: F = -b0;
+        Self {
+            a1,
+            a2,
+            b0,
+            b1,
+            b2,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Arbitrary biquad.
+    #[inline]
+    pub fn arbitrary(a1: F, a2: F, b0: F, b1: F, b2: F) -> Self {
+        Self {
+            a1,
+            a2,
+            b0,
+            b1,
+            b2,
+            _marker: PhantomData,
+        }
+    }
+
+    ///// Frequency response at frequency `omega` expressed as fraction of sampling rate.
+    //pub fn response(&self, omega: f64) -> Complex64 {
+    //    let z1 = Complex64::from_polar(1.0, -f64::TAU * omega);
+    //    let z2 = z1 * z1;
+    //    /// Complex64 with real component `x` and imaginary component zero.
+    //    fn re<T: Float>(x: T) -> Complex64 {
+    //        Complex64::new(x.to_f64(), 0.0)
+    //    }
+    //    (re(self.b0) + re(self.b1) * z1 + re(self.b2) * z2)
+    //        / (re(1.0) + re(self.a1) * z1 + re(self.a2) * z2)
+    //}
+}
+
+/// 2nd order IIR filter-bank implemented in normalized Direct Form I and SIMD.
+/// - Setting: coefficients as tuple Parameter::BiquadBank(a1, a2, b0, b1, b2).
+/// - Input 0: input signal.
+/// - Output 0: filtered signal.
+#[derive(Default, Clone)]
+pub struct BiquadBank<F, Size>
+where
+    F: Realx<Size>,
+    Size: ArrayLength + Sync + Send,
+{
+    coefs: BiquadCoefsBank<F, Size>,
+    x1: F,
+    x2: F,
+    y1: F,
+    y2: F,
+    sample_rate: f64,
+}
+
+impl<F, Size> BiquadBank<F, Size>
+where
+    F: Realx<Size>,
+    Size: ArrayLength + Sync + Send,
+{
+    pub fn new() -> Self {
+        Self {
+            sample_rate: DEFAULT_SR,
+            ..Default::default()
+        }
+    }
+    pub fn with_coefs(coefs: BiquadCoefsBank<F, Size>) -> Self {
+        Self {
+            coefs,
+            sample_rate: DEFAULT_SR,
+            ..Default::default()
+        }
+    }
+    pub fn coefs(&self) -> &BiquadCoefsBank<F, Size> {
+        &self.coefs
+    }
+    pub fn set_coefs(&mut self, coefs: BiquadCoefsBank<F, Size>) {
+        self.coefs = coefs;
+    }
+}
+
+impl<F, Size> AudioNode for BiquadBank<F, Size>
+where
+    F: Realx<Size>,
+    Size: ArrayLength + Sync + Send,
+{
+    const ID: u64 = 15;
+    type Inputs = typenum::U1;
+    type Outputs = Size;
+
+    fn reset(&mut self) {
+        self.x1 = F::zero();
+        self.x2 = F::zero();
+        self.y1 = F::zero();
+        self.y2 = F::zero();
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f64) {
+        self.sample_rate = sample_rate;
+    }
+
+    #[inline]
+    fn tick(&mut self, input: &Frame<f32, Self::Inputs>) -> Frame<f32, Self::Outputs> {
+        let x0 = F::from_f32(input[0]);
+        let y0 = self.coefs.b0 * x0 + self.coefs.b1 * self.x1 + self.coefs.b2 * self.x2
+            - self.coefs.a1 * self.y1
+            - self.coefs.a2 * self.y2;
+        self.x2 = self.x1;
+        self.x1 = x0;
+        self.y2 = self.y1;
+        self.y1 = y0;
+        y0.to_frame()
+    }
+
+    //fn set(&mut self, setting: Setting) {
+    //    if let Parameter::BiquadBank(a1, a2, b0, b1, b2) = setting.parameter() {
+    //        self.set_coefs(BiquadCoefsBank::arbitrary(*a1, *a2, *b0, *b1, *b2));
+    //    }
+    //}
+
+    //fn route(&mut self, input: &SignalFrame, frequency: f64) -> SignalFrame {
+    //    let mut output = SignalFrame::new(self.outputs());
+    //    output.set(
+    //        0,
+    //        input.at(0).filter(0.0, |r| {
+    //            r * self.coefs().response(frequency / self.sample_rate)
+    //        }),
+    //    );
+    //    output
+    //}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,61 @@ impl Num for F32x {
     }
 }
 
+impl Num for wide::f64x4 {
+    #[inline(always)]
+    fn zero() -> Self {
+        wide::f64x4::ZERO
+    }
+    #[inline(always)]
+    fn one() -> Self {
+        wide::f64x4::ONE
+    }
+    #[inline(always)]
+    fn new(x: i64) -> Self {
+        wide::f64x4::splat(x as f64)
+    }
+    #[inline(always)]
+    fn from_f64(x: f64) -> Self {
+        wide::f64x4::splat(x)
+    }
+    #[inline(always)]
+    fn from_f32(x: f32) -> Self {
+        wide::f64x4::splat(x as f64)
+    }
+    #[inline(always)]
+    fn abs(self) -> Self {
+        self.abs()
+    }
+    #[inline(always)]
+    fn signum(self) -> Self {
+        wide::f64x4::ONE.copysign(self)
+    }
+    #[inline(always)]
+    fn min(self, other: Self) -> Self {
+        self.fast_min(other)
+    }
+    #[inline(always)]
+    fn max(self, other: Self) -> Self {
+        self.fast_max(other)
+    }
+    #[inline(always)]
+    fn pow(self, other: Self) -> Self {
+        self.pow_f64x4(other)
+    }
+    #[inline(always)]
+    fn floor(self) -> Self {
+        (self - 0.4999999).round()
+    }
+    #[inline(always)]
+    fn ceil(self) -> Self {
+        (self + 0.4999999).round()
+    }
+    #[inline(always)]
+    fn round(self) -> Self {
+        self.round()
+    }
+}
+
 /// Integer abstraction.
 pub trait Int:
     Num
@@ -519,6 +574,7 @@ pub mod adsr;
 pub mod audionode;
 pub mod audiounit;
 pub mod biquad;
+pub mod biquad_bank;
 pub mod buffer;
 pub mod combinator;
 pub mod delay;

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -28,6 +28,11 @@ pub enum Parameter {
     Coefficient(f32),
     /// Set biquad parameters `(a1, a2, b0, b1, b2)`.
     Biquad(f32, f32, f32, f32, f32),
+    /// Set biquadbank parameters `(index, a1, a2, b0, b1, b2)`.
+    /// `index` range:
+    /// - 0-3 for a f64x4 based BiquadBank
+    /// - 0-7 for a f32x8 based BiquadBank
+    BiquadBank(usize, f32, f32, f32, f32, f32),
     /// Set delay.
     Delay(f32),
     /// Set response time.


### PR DESCRIPTION
### Why

This is a prototype. As I am somebody who can tinker on things forever. I want to get it out early. This does not mean I want it to be committed like that.

I am building a vocoder like thing with formant/pitch-shift. Therefore I need a ton of resonators and I want them to be as fast as possible.

### What

I implemented the trait `Realx` based on `Num` as an analog to `Real`. It is intended to work with f32x8 and f64x4. I first wanted to drop f64x4, but then I heard from @SamiPerttu that they are going to (re)introduce 64-bit to simd. Then I took `BiquadCoefs` and removed everything but `resonator()`. I slightly changed the calculations. I introduced the generic parameter `Size` to `BiquadBank` and used it for `type Outputs` and for some strange reason not for `type Inputs`, but I need to change this.

### TODO

- [ ] I need to investigate how things are tested in funDSP.
- [x] Implement `Size` for `type Inputs`
- [x] Get `fn set()` to work (EDIT: like below)
- [ ] Get `fn route()` and `fn response()` to work

### Performance

```shell
ganwell•~/Repos/fundsp_player(main)» /usr/bin/time target/release/player bank_simd dummy --seconds 400
        0.39 real         0.38 user         0.00 sys
ganwell•~/Repos/fundsp_player(main)» /usr/bin/time target/release/player bank_current dummy --seconds 400
        1.12 real         1.11 user         0.00 sys
```

Based on [this code](https://github.com/rhizoome/fundsp_player/blob/ea7ccfd656c482afb7e22d374bd8498dd994f6a7/src/build.rs#L32) run on an Apple M1.

### Assumptions

- I think `BiquadBank` should take N inputs and N outputs, since this is the generic part. Usually resonator-banks use one input and one output. Strangely the current implementation takes 1 input and N outputs, just for reasons. I am going to change that, but I wanted to get something out early.
- I used `sample_rate: f32` on `fn resonator()` without checking if that is compliant with the rest of `fundsp`.
- I assumed that implementing `fn set()` properly would be complicated since we would introduce generic-parameters on `Settings`, but maybe there is a nice trick to avoid that.
- There are probably more (incorrect) assumption I made, please let me know.

### Questions

- `fn response()` and `fn route()` confuse me. How do I build that for multiple channels? I guess the confusion stems from not understanding the purpose of either. Given enough time passes, I'll investigate and understand it. But any hints are welcome.
- If those who review this see mistakes I did in [fundsp_player](https://github.com/rhizoome/fundsp_player), let me know. I tried to use block processing, to get best performance. I already changed to typnum-type to U8, but above I linked to exact version I did the performance test with.

### Plans

Of course if my idea of biquad_bank.rs does not fit funDSP that is absolutely fine. If possible I like to merge some correct, but minimal version of biquad_bank.rs and build from there. But I am also okey with leaving this PR open till there is a respectable amount of filter-banks. 
