### PR TITLE
Fix incorrect panic message in `net.rs` for bus operation

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -1682,8 +1682,8 @@ impl Net {
         if net1.inputs() != net2.inputs() {
             panic!(
                 "Net::bus: mismatched inputs ({} versus {}).",
-                net1.outputs(),
-                net2.outputs()
+                net1.inputs(),
+                net2.inputs()
             );
         }
         if net1.outputs() != net2.outputs() {


### PR DESCRIPTION
Fix the panic message that wrongly reports the size of the outputs, when the size of the inputs is not matching during bus of two networks.