### PR TITLE
Return `None` from `Sequencer::time()` if it has a backend

### DIFF
--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -296,9 +296,13 @@ impl Sequencer {
     }
 
     /// Current time in seconds.
-    /// This method is not applicable to frontends, which do not process audio.
-    pub fn time(&self) -> f64 {
-        self.time
+    /// Returns `None` if this sequencer has a backend.
+    pub fn time(&self) -> Option<f64> {
+        if self.has_backend() {
+            None
+        } else {
+            Some(self.time)
+        }
     }
 
     /// Add an event. All times are specified in seconds.


### PR DESCRIPTION
I ran into a bug where I was using `sequencer.time()` on a frontend, which had worked when it didn't have a backend, but silently broke when I later refactored my code to give it a backend.

Making `Sequencer::time()` return an `Option` would have surfaced this bug, assuming I used `.unwrap()` on the option.