### PR TITLE
Net.fade_in: fix DummyUnit's silence

### DIFF
--- a/src/audiounit.rs
+++ b/src/audiounit.rs
@@ -675,7 +675,7 @@ impl AudioUnit for DummyUnit {
 
     fn process(&mut self, size: usize, _input: &BufferRef, output: &mut BufferMut) {
         for channel in 0..self.outputs {
-            output.channel_f32_mut(channel)[0..simd_items(size)].fill(0.0);
+            output.channel_mut(channel)[0..simd_items(size)].fill(F32x::ZERO);
         }
     }
 


### PR DESCRIPTION
when fading in units, it uses a `DummyUnit` which only output silence. while `tick` is correctly implemented, `process` doesn't set the whole wanted output range.