### PR TITLE
Add Wavetable constructor that performs per-table normalization

### DIFF
--- a/src/wavetable.rs
+++ b/src/wavetable.rs
@@ -122,6 +122,40 @@ impl Wavetable {
         Wavetable { table }
     }
 
+    /// Create new wavetable with per-table normalization.
+    /// Each table is independently normalized to ensure
+    /// consistent output level across all pitches.
+    ///
+    /// Arguments are the same as [`Wavetable::new`].
+    pub fn new_normalized<P, A>(
+        min_pitch: f64,
+        max_pitch: f64,
+        tables_per_octave: f64,
+        phase: &P,
+        amplitude: &A,
+    ) -> Wavetable
+    where
+        P: Fn(u32) -> f64,
+        A: Fn(f64, u32) -> f64,
+    {
+        let mut table: Vec<(f32, Vec<f32>)> = vec![];
+        let mut pitch = min_pitch;
+        let p_factor = pow(2.0, 1.0 / tables_per_octave);
+        while pitch <= max_pitch {
+            let wave = make_wave(pitch, phase, amplitude);
+            table.push((pitch as f32, wave));
+            pitch *= p_factor;
+        }
+        for t in table.iter_mut() {
+            let max_amplitude = t.1.iter().fold(0.0f32, |acc, &x| max(acc, abs(x)));
+            if max_amplitude > 0.0 {
+                let z = 1.0 / max_amplitude;
+                t.1.iter_mut().for_each(|x| *x *= z);
+            }
+        }
+        Wavetable { table }
+    }
+
     /// Create new wavetable from a single cycle wave.
     /// The length of `wave` must be a power of two between 2 and 32768.
     /// `min_pitch` and `max_pitch` are the minimum


### PR DESCRIPTION
This PR adds `Wavetable::new_normalized` that performs normalization for each generated table instead of applying uniform gain across all generated tables. Without this, wavetables that do not have a strong fundamental end up much quieter in high octaves compared to low octaves.

This is a comparison of the two constructors, playing C0, C1, C2, C3, C4 to compare:
<img width="1257" height="244" alt="Screenshot 2026-04-17 at 10 00 48" src="https://github.com/user-attachments/assets/c8cd71d1-d0ec-402f-99b3-914bc33d9bb1" />

I am open to changing the name of this constructor function if you prefer.