### PR TITLE
Fix no_std build without default features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
+      - run: cargo check
+      - run: cargo check --no-default-features
 
   lint:
     runs-on: ubuntu-latest

--- a/src/oversample.rs
+++ b/src/oversample.rs
@@ -6,6 +6,7 @@ use super::graph::*;
 use super::math::*;
 use super::signal::*;
 use super::*;
+use alloc::vec::Vec;
 use numeric_array::typenum::*;
 
 #[inline]

--- a/src/realseq.rs
+++ b/src/realseq.rs
@@ -6,6 +6,8 @@ use super::math::*;
 use super::sequencer::*;
 use super::signal::*;
 use super::*;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use tinyvec::TinyVec;
 
 #[derive(Default, Clone)]


### PR DESCRIPTION
I noticed that the releases and the master branch is both failing to compile with default features OFF (no-std mode). This change meant to fix it, while also adding a check to CI to catch this next time.